### PR TITLE
Tweak error message for functional

### DIFF
--- a/src/graders/functional.arr
+++ b/src/graders/functional.arr
@@ -30,11 +30,11 @@ fun fmt-functional-test(check-name :: String, score :: G.NormalizedNumber, info)
   general = output-markdown(cases(Either) info:
     | left(_) =>
       "An error occured while trying to run our tests against your " +
-      " implementation of `" + check-name + "`." +
-      "Make sure your function is defined"
+      " implementation in `" + check-name + "`." +
+      " Make sure your function is defined"
     | right({passed; total; _}) =>
       "**" + to-repr(passed) + "** of our **" + to-repr(total) + "** checks " +
-      "succeeded againt your own implementation of `" + check-name + "`."
+      "succeeded againt your own implementation in `" + check-name + "`."
   end)
   # TODO: format nicely
   staff = output-text(cases(Either) info:


### PR DESCRIPTION
This both fixes a spacing error, and also the fact that the name of the test is often not the name of the function, it might be `function-name functional`. Perhaps that's a mistake, but this seems like a minor tweak that will improve things.