### PR TITLE
function definition guard

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
           packages = with pkgs; [
             nodejs_24
             gnumake
-          ];
+          ] ++ lib.optionals stdenv.isDarwin [ git ];
         };
       });
     };

--- a/src/graders/fn-def-guard.arr
+++ b/src/graders/fn-def-guard.arr
@@ -1,0 +1,97 @@
+import npm("pyret-lang", "../../src/arr/compiler/well-formed.arr") as WF
+import npm("pyret-lang", "../../src/arr/compiler/compile-structs.arr") as CS
+import npm("pyret-lang", "../../src/arr/compiler/ast-util.arr") as AU
+import file("../core.arr") as C
+import file("../grading.arr") as G
+import file("../grading-builders.arr") as GB
+import file("../common/ast.arr") as CA
+import file("../common/markdown.arr") as MD
+import ast as A
+
+include either
+include from C:
+  type Id
+end
+
+provide:
+  mk-def-guard,
+  data DefGuardBlock,
+  check-fun-defined as _check-fun-defined,
+  fmt-fun-def as _fmt-fun-def
+end
+
+data DefGuardBlock:
+  | parser-error(err :: CA.ParsePathErr) # this should've been caught by wf
+  | fn-not-defined(name :: String, arity :: Number)
+  | wrong-arity(name :: String, expected :: Number, actual :: Number)
+end
+
+fun check-fun-defined(
+  path :: String,
+  name :: String,
+  arity :: Number
+) -> Option<DefGuardBlock>:
+  cases (Either) CA.parse-path(path):
+    | left(err) => some(parser-error(err))
+    | right(ast) =>
+      ast-ended = AU.append-nothing-if-necessary(ast)
+      cases (A.Program) ast-ended:
+        | s-program(_, _, _, _, _, _, body) =>
+          cases (A.Expr) body:
+            | s-block(_, stmts) => find-def(stmts, name, arity)
+            | else => some(fn-not-defined(name, arity))
+          end
+      end
+  end
+end
+
+fun find-def(
+  stmts :: List<A.Expr>,
+  expected-name :: String,
+  expected-arity :: Number
+) -> Option<DefGuardBlock>:
+  cases (List) stmts:
+    | empty => some(fn-not-defined(expected-name, expected-arity))
+    | link(st, rest) =>
+      cases (A.Expr) st:
+        | s-fun(_, actual-name, _, args, _, _, _, _, _, _) =>
+          if actual-name == expected-name:
+            actual-arity = args.length()
+            if actual-arity == expected-arity:
+              none
+            else:
+              some(wrong-arity(expected-name, expected-arity, actual-arity))
+            end
+          else:
+            find-def(rest, expected-name, expected-arity)
+          end
+        | else => find-def(rest, expected-name, expected-arity)
+      end
+  end
+end
+
+fun fmt-fun-def(reason :: DefGuardBlock) -> GB.ComboAggregate:
+  student = cases (DefGuardBlock) reason:
+    | parser-error(_) =>
+      # assuming we depend on wf, wes should never see this case
+      # so hopefully it's fine to have a bad error here
+      "Cannot find your function definition because we cannot parse your file."
+    | fn-not-defined(name, arity) =>
+      "Cannot find a function definiton named " + MD.escape-inline-code(name) +
+      ". We expect a function " + MD.escape-inline-code(name) + " taking " +
+      num-to-string(arity) + " arguments. Perhaps you mistyped the function name."
+    | wrong-arity(name, expected, actual) =>
+      "The definition for function " + MD.escape-inline-code(name) + 
+      " should have " + num-to-string(expected) + " arguments, but seems to have " +
+      num-to-string(actual) + " arguments instead. Make sure your function is " +
+      "defined correctly."
+  end ^ G.output-markdown
+  staff = none
+  {student; staff}
+end
+
+fun mk-def-guard(id :: Id, deps :: List<Id>, path :: String, fn-name :: String, arity :: Number):
+  name = "Find function " + fn-name + " with " + num-to-string(arity) + " arguments"
+  checker = lam(): check-fun-defined(path, fn-name, arity) end
+  GB.mk-guard(id, deps, checker, name, fmt-fun-def)
+end

--- a/tests/files/foo-one-arg.arr
+++ b/tests/files/foo-one-arg.arr
@@ -1,0 +1,1 @@
+fun foo(a :: String) -> String: a end

--- a/tests/files/foo-two-args.arr
+++ b/tests/files/foo-two-args.arr
@@ -1,0 +1,1 @@
+fun foo(a :: String, b :: Number) -> String: a end

--- a/tests/files/no-foo.arr
+++ b/tests/files/no-foo.arr
@@ -1,0 +1,1 @@
+fun bar(): nothing end

--- a/tests/graders/fn-def-guard.arr
+++ b/tests/graders/fn-def-guard.arr
@@ -1,0 +1,27 @@
+import file("../meta/path-utils.arr") as P
+import file("../../src/common/ast.arr") as CA
+include file("../../src/graders/fn-def-guard.arr")
+
+check-fun-defined = _check-fun-defined
+fmt-fun-def = _fmt-fun-def
+
+check "fn-def: not present":
+  path = P.file("no-foo.arr")
+  check-fun-defined(path, "foo", 1) is some(fn-not-defined("foo", 1))
+end
+
+check "fn-def: wrong arity":
+  path = P.file("foo-two-args.arr")
+  check-fun-defined(path, "foo", 1) is some(wrong-arity("foo", 1, 2))
+end
+
+check "fn-def: correct":
+  path = P.file("foo-one-arg.arr")
+  check-fun-defined(path, "foo", 1) is none
+end
+
+check "fmt-fun-def: totality":
+  fmt-fun-def(parser-error(CA.path-doesnt-exist("/invalid/file.arr"))) does-not-raise
+  fmt-fun-def(fn-not-defined("foo", 1)) does-not-raise
+  fmt-fun-def(wrong-arity("foo", 1, 2)) does-not-raise
+end

--- a/tests/graders/main.arr
+++ b/tests/graders/main.arr
@@ -17,3 +17,4 @@
   with pyret-autograder. If not, see <http://www.gnu.org/licenses/>.
 |#
 import file("./well-formed.arr") as _
+import file("./fn-def-guard.arr") as _


### PR DESCRIPTION
add syntactic check to make sure a function is defined with the right arity

currently does not report a good error for students assigning a _non-function_ to the identifier we're looking for (it reports it as no such definition found)