### PR TITLE
training wheels

### DIFF
--- a/src/graders/main.arr
+++ b/src/graders/main.arr
@@ -22,6 +22,7 @@ import file("./functional.arr") as functional
 import file("./examplar.arr") as examplar
 import file("./fn-def-guard.arr") as fn-def
 import file("./test-diversity.arr") as test-diversity
+import file("./training-wheels.arr") as training-wheels
 
 # NOTE: only provides the functions, everything else should be an
 # implementation detail and can be imported directly from the module
@@ -32,3 +33,4 @@ provide from functional: * end
 provide from examplar: * end
 provide from fn-def: * end
 provide from test-diversity: * end
+provide from training-wheels: * end

--- a/src/graders/training-wheels.arr
+++ b/src/graders/training-wheels.arr
@@ -1,0 +1,142 @@
+import file("../core.arr") as C
+import file("../grading.arr") as G
+import file("../grading-builders.arr") as GB
+import file("../common/ast.arr") as CA
+import file("../common/markdown.arr") as MD
+import file("../common/visitors.arr") as V
+import file("../common/repl-runner.arr") as R
+
+import ast as A
+import srcloc as SL
+
+include either
+include from C:
+  type Id
+end
+
+provide:
+  data TrainingWheelsBlock,
+  mk-training-wheels-guard,
+  find-mutation as _find-mutation,
+  fmt-training-wheels as _fmt-training-wheels
+end
+
+data TrainingWheelsBlock:
+  | parser-error(err :: CA.ParsePathErr)
+  | found-mutation(vars :: List<SL.Srcloc>, refs :: List<SL.Srcloc>, tl-only :: Boolean)
+end
+
+fun find-mutation(path :: String, top-level-only :: Boolean) -> Option<TrainingWheelsBlock>:
+  # TODO: better heuristics for finding refs, and maybe allow non-top-level ones
+  cases (Either) CA.parse-path(path):
+  | left(err) => some(parser-error(err))
+  | right(ast) =>
+    cases (A.Program) ast:
+    | s-program(_, _, _, _, _, _, e) =>
+      vars = if top-level-only: top-level-vars(e)
+      else: all-vars(e)
+      end
+      refs = all-refs(e)
+      if (vars.length() == 0) and (refs.length() == 0):
+        none
+      else:
+        some(found-mutation(vars, refs, top-level-only))
+      end
+    end
+  end
+end
+
+fun top-level-vars(e :: A.Expr) -> List<SL.Srcloc>:
+  fun filter-map<T, U>(pred :: (T -> Option<U>), l :: List<T>) -> List<U>:
+    cases (List) l:
+    | empty => empty
+    | link(f, r) =>
+      cases (Option) pred(f):
+      | none => filter-map(pred, r)
+      | some(v) => link(v, filter-map(pred, r))
+      end
+    end
+  end
+
+  cases (A.Expr) e:
+  | s-block(_, stmts) =>
+    filter-map(lam(st):
+      cases (A.Expr) st:
+      | s-var(l, _, _) => some(l)
+      | else => none
+      end
+    end, stmts)
+  | else => raise("top-level-vars: expects s-block of whole program")
+  end
+end
+
+fun all-vars(e :: A.Expr) -> List<SL.Srcloc> block:
+  var found = [list:]
+  visitor = A.default-iter-visitor.{
+    method s-var(self, l, _, _) block:
+      found := link(l, found)
+      true
+    end
+  }
+  e.visit(visitor)
+  found.reverse()
+end
+
+fun all-refs(e :: A.Expr) -> List<SL.Srcloc> block:
+  var found = [list:]
+  visitor = A.default-iter-visitor.{
+    method s-ref(self, l, _) block:
+      found := link(l, found)
+      true
+    end,
+    method s-variant-member(self, l, ty :: A.VariantMemberType, _) block:
+      cases (A.VariantMemberType) ty:
+      | s-mutable => found := link(l, found)
+      | else => nothing
+      end
+      true
+    end
+  }
+  e.visit(visitor)
+  found.reverse()
+end
+
+fun fmt-training-wheels(reason :: TrainingWheelsBlock) -> GB.ComboAggregate:
+  fun format-srcloc-list(l :: List<SL.Srcloc>) -> String:
+    l.map("- " + _.format()).join-str("\n")
+  end
+  student = cases (TrainingWheelsBlock) reason:
+  | parser-error(_) =>
+    "Cannot find your function definition because we cannot parse your file."
+  | found-mutation(vars, refs, tl-only) =>
+    formatted-vars =
+      "Found mutable variables at:\n" + format-srcloc-list(vars)
+    formatted-refs =
+      "Found references used at:\n" + format-srcloc-list(refs)
+    var-message =
+      "We found uses of mutation in your program that are not allowed."
+    + (if tl-only:
+      " Mutable variables are not allowed at the top-level of your programs. "
+      else:
+        " Mutable variables are not yet allowed in your programs. "
+      end)
+    + formatted-vars
+    ref-message =
+      "Referencess are a mutable feature that cannot be used at this time. "
+      + formatted-refs
+    if vars.length() > 0: var-message
+    else: ""
+    end
+    + if refs.length() > 0: "\n" + ref-message
+      else: ""
+      end
+  end ^ G.output-markdown
+  staff = none
+  {student; staff}
+end
+
+fun mk-training-wheels-guard(id :: Id, deps :: List<Id>, path :: String, top-level-only :: Boolean):
+  name = "Training wheels"
+  checker = lam(): find-mutation(path, top-level-only) end
+  GB.mk-guard(id, deps, checker, name, fmt-training-wheels)
+end

--- a/tests/files/inner-mutation.arr
+++ b/tests/files/inner-mutation.arr
@@ -1,0 +1,7 @@
+fun foo():
+  var counter = 1
+  lam() block:
+    counter := counter + 1
+    counter
+  end
+end

--- a/tests/files/nested-fun-var.arr
+++ b/tests/files/nested-fun-var.arr
@@ -1,0 +1,7 @@
+fun foo():
+  fun bar(x):
+    var v = 0
+    x
+  end
+  bar(3)
+end

--- a/tests/files/top-level-mutation.arr
+++ b/tests/files/top-level-mutation.arr
@@ -1,0 +1,7 @@
+var counter = 0
+
+fun foo() block:
+  var inner = 0
+  counter := counter + 1
+  counter
+end

--- a/tests/files/use-ref.arr
+++ b/tests/files/use-ref.arr
@@ -1,0 +1,7 @@
+data Bar:
+  | branch(ref x)
+end
+
+fun foo():
+  branch(1)
+end

--- a/tests/graders/main.arr
+++ b/tests/graders/main.arr
@@ -19,3 +19,4 @@
 import file("./well-formed.arr") as _
 import file("./fn-def-guard.arr") as _
 import file("./test-diversity.arr") as _
+import file("./training-wheels.arr") as _

--- a/tests/graders/training-wheels.arr
+++ b/tests/graders/training-wheels.arr
@@ -15,6 +15,11 @@ fun only-lines(l :: List<Srcloc>) -> List<Srcloc>:
 end
 
 fun portable(result :: Option<TrainingWheelsBlock>) -> Option<TrainingWheelsBlock>:
+  doc: ```
+  Strip machine-specific information from srclocs in a block. Removes volatile
+  information like the absolute file path and column numbers which are harder to
+  test against.
+  ```
   cases (Option) result:
   | none => none
   | some(b) =>
@@ -39,17 +44,21 @@ check "training-wheels: flags mutation":
         [list:],
         true
     ))
+
   portable(find-mutation(P.file("inner-mutation.arr"), false)) is
     some(found-mutation(
         [list: srcloc("", 2, 0, 0, 2, 0, 0)],
         [list:],
         false
     ))
-
   portable(find-mutation(P.file("inner-mutation.arr"), true)) is none
 
   portable(find-mutation(P.file("use-ref.arr"), false)) is
     some(found-mutation([list: ], [list: srcloc("", 2, 0, 0, 2, 0, 0)], false))
   portable(find-mutation(P.file("use-ref.arr"), true)) is
     some(found-mutation([list: ], [list: srcloc("", 2, 0, 0, 2, 0, 0)], true))
+
+  portable(find-mutation(P.file("nested-fun-var.arr"), true)) is none
+  portable(find-mutation(P.file("nested-fun-var.arr"), false)) is
+    some(found-mutation([list: srcloc("", 3, 0, 0, 3, 0, 0)], [list:], false))
 end

--- a/tests/graders/training-wheels.arr
+++ b/tests/graders/training-wheels.arr
@@ -1,0 +1,55 @@
+import file("../meta/path-utils.arr") as P
+include file("../../src/graders/training-wheels.arr")
+include srcloc
+
+find-mutation = _find-mutation
+
+fun only-lines(l :: List<Srcloc>) -> List<Srcloc>:
+  l.map(lam(x):
+    cases (Srcloc) x:
+    | builtin(mod) => builtin(mod)
+    | srcloc(_, sl, _, _, el, _, _) =>
+        srcloc("", sl, 0, 0, el, 0, 0)
+    end
+  end)
+end
+
+fun portable(result :: Option<TrainingWheelsBlock>) -> Option<TrainingWheelsBlock>:
+  cases (Option) result:
+  | none => none
+  | some(b) =>
+    some(cases (TrainingWheelsBlock) b:
+    | parser-error(e) => parser-error(e)
+    | found-mutation(vars, refs, tl) =>
+      found-mutation(only-lines(vars), only-lines(refs), tl)
+    end)
+  end
+end
+
+check "training-wheels: flags mutation":
+  portable(find-mutation(P.file("top-level-mutation.arr"), false)) is
+    some(found-mutation(
+        [list: srcloc("", 1, 0, 0, 1, 0, 0), srcloc("", 4, 0, 0, 4, 0, 0)],
+        [list:],
+        false
+    ))
+  portable(find-mutation(P.file("top-level-mutation.arr"), true)) is
+    some(found-mutation(
+        [list: srcloc("", 1, 0, 0, 1, 0, 0)],
+        [list:],
+        true
+    ))
+  portable(find-mutation(P.file("inner-mutation.arr"), false)) is
+    some(found-mutation(
+        [list: srcloc("", 2, 0, 0, 2, 0, 0)],
+        [list:],
+        false
+    ))
+
+  portable(find-mutation(P.file("inner-mutation.arr"), true)) is none
+
+  portable(find-mutation(P.file("use-ref.arr"), false)) is
+    some(found-mutation([list: ], [list: srcloc("", 2, 0, 0, 2, 0, 0)], false))
+  portable(find-mutation(P.file("use-ref.arr"), true)) is
+    some(found-mutation([list: ], [list: srcloc("", 2, 0, 0, 2, 0, 0)], true))
+end


### PR DESCRIPTION
check program ast for any `var`s or `ref`s and block if they are found. `var` checking is configurable to only search for top-level or all uses so training wheels can "come off" as the course progresses

closes #15
closes #18 